### PR TITLE
Fix wrong restore of scroll position when navigating back from detail

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,6 +123,7 @@ google-accompanistNavigationMaterial = { module = "com.google.accompanist:accomp
 google-accompanistPager = { module = "com.google.accompanist:accompanist-pager", version.ref = "google-accompanist" }
 google-accompanistPagerInd = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "google-accompanist" }
 google-accompanistPermissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "google-accompanist" }
+google-accompanistPlaceholderMaterial = { module = "com.google.accompanist:accompanist-placeholder-material", version.ref = "google-accompanist" }
 google-accompanistSystemUi = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "google-accompanist" }
 google-dagger = { module = "com.google.dagger:dagger", version.ref = "google-dagger" }
 google-daggerCompiler = { module = "com.google.dagger:dagger-compiler", version.ref = "google-dagger" }

--- a/trending/build.gradle.kts
+++ b/trending/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   implementation(libs.coilCompose)
   implementation(libs.androidx.pagingRuntime)
   implementation(libs.androidx.pagingCompose)
+  implementation(libs.google.accompanistPlaceholderMaterial)
   implementation(libs.square.sqlDelightAndroidPaging3)
   implementation(libs.square.sqlDelightCoroutines)
   testImplementation(libs.square.turbine)

--- a/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/Movie.kt
+++ b/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/Movie.kt
@@ -1,0 +1,101 @@
+package net.marcoromano.mooviez.trending.widgets.trending
+
+import android.graphics.drawable.ColorDrawable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import net.marcoromano.mooviez.database.Movie
+import net.marcoromano.mooviez.widgets.UserScore
+
+@Composable
+internal fun Movie(
+  movie: Movie,
+  navToDetail: (id: Long) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .padding(8.dp)
+      .width(160.dp)
+      .clickable { navToDetail(movie.id) },
+  ) {
+    Box {
+      Column {
+        Image(
+          painter = rememberAsyncImagePainter(
+            model = ImageRequest.Builder(LocalContext.current)
+              .data("https://image.tmdb.org/t/p/w500/${movie.poster_path}")
+              .size(width = 500, height = 750)
+              .placeholder(ColorDrawable(MaterialTheme.colorScheme.onSurfaceVariant.toArgb()))
+              .error(android.R.drawable.ic_dialog_alert) // TODO: Can be better looking.
+              .crossfade(true)
+              .build(),
+          ),
+          contentDescription = null,
+          modifier = Modifier
+            .aspectRatio(500f / 750f)
+            .clip(RoundedCornerShape(32f)),
+          contentScale = ContentScale.Fit,
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+      }
+      UserScore(
+        modifier = Modifier
+          .align(Alignment.BottomStart)
+          .padding(8.dp),
+        userScore = (movie.vote_average * 10).toInt(),
+      )
+    }
+    Column(
+      modifier = Modifier.padding(8.dp),
+    ) {
+      Text(
+        text = movie.title,
+        fontWeight = FontWeight.Bold,
+      )
+      Spacer(modifier = Modifier.height(4.dp))
+      Text(
+        modifier = Modifier.alpha(0.5f),
+        text = movie.release_date,
+      )
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+  Movie(
+    movie = Movie(
+      position = 0,
+      id = 0,
+      title = "A very long title that must be wrapped in multiple lines",
+      poster_path = "https://dummyimage.com/500x750/000/fff.jpg",
+      overview = "Once upon a time...",
+      vote_average = 1.2,
+      release_date = "2022-02-03",
+    ),
+    navToDetail = {},
+  )
+}

--- a/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/MoviePlaceHolder.kt
+++ b/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/MoviePlaceHolder.kt
@@ -1,0 +1,69 @@
+package net.marcoromano.mooviez.trending.widgets.trending
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.placeholder.material.placeholder
+import net.marcoromano.mooviez.widgets.UserScore
+
+@Composable
+internal fun MoviePlaceHolder() {
+  Column(
+    modifier = Modifier
+      .padding(8.dp)
+      .width(160.dp),
+  ) {
+    Box {
+      Column {
+        Box(
+          modifier = Modifier
+            .placeholder(true)
+            .aspectRatio(500f / 750f)
+            .clip(RoundedCornerShape(32f)),
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+      }
+      UserScore(
+        modifier = Modifier
+          .align(Alignment.BottomStart)
+          .padding(8.dp),
+        userScore = 0,
+      )
+    }
+    Column(
+      modifier = Modifier.padding(8.dp),
+    ) {
+      Text(
+        text = "Lorem ipsum lorem ipsum",
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.placeholder(true),
+      )
+      Spacer(
+        modifier = Modifier.height(4.dp),
+      )
+      Text(
+        modifier = Modifier.placeholder(true),
+        text = "1999-01-01",
+      )
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+  MoviePlaceHolder()
+}

--- a/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/TrendingLazyVerticalGrid.kt
+++ b/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/TrendingLazyVerticalGrid.kt
@@ -1,44 +1,17 @@
 package net.marcoromano.mooviez.trending.widgets.trending
 
-import android.graphics.drawable.ColorDrawable
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import net.marcoromano.mooviez.database.Movie
-import net.marcoromano.mooviez.widgets.UserScore
 
 @Composable
 internal fun TrendingLazyVerticalGrid(
@@ -75,84 +48,10 @@ private fun TrendingLazyVerticalGrid(
           navToDetail = { onMovieClick(it) },
         )
       } else {
-        Icon(
-          imageVector = Icons.Default.Error,
-          contentDescription = null,
-        )
+        MoviePlaceHolder()
       }
     }
   }
-}
-
-@Composable
-private fun Movie(
-  movie: Movie,
-  navToDetail: (id: Long) -> Unit,
-) {
-  Column(
-    modifier = Modifier
-      .padding(8.dp)
-      .width(160.dp)
-      .clickable { navToDetail(movie.id) },
-  ) {
-    Box {
-      Column {
-        Image(
-          painter = rememberAsyncImagePainter(
-            model = ImageRequest.Builder(LocalContext.current)
-              .data("https://image.tmdb.org/t/p/w500/${movie.poster_path}")
-              .size(width = 500, height = 750)
-              .placeholder(ColorDrawable(MaterialTheme.colorScheme.onSurfaceVariant.toArgb()))
-              .error(android.R.drawable.ic_dialog_alert) // TODO: Can be better looking.
-              .crossfade(true)
-              .build(),
-          ),
-          contentDescription = null,
-          modifier = Modifier
-            .aspectRatio(500f / 750f)
-            .clip(RoundedCornerShape(32f)),
-          contentScale = ContentScale.Fit,
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-      }
-      UserScore(
-        modifier = Modifier
-          .align(Alignment.BottomStart)
-          .padding(8.dp),
-        userScore = (movie.vote_average * 10).toInt(),
-      )
-    }
-    Column(
-      modifier = Modifier.padding(8.dp),
-    ) {
-      Text(
-        text = movie.title,
-        fontWeight = FontWeight.Bold,
-      )
-      Spacer(modifier = Modifier.height(4.dp))
-      Text(
-        modifier = Modifier.alpha(0.5f),
-        text = movie.release_date,
-      )
-    }
-  }
-}
-
-@Preview
-@Composable
-private fun PreviewMovie() {
-  Movie(
-    movie = Movie(
-      position = 0,
-      id = 0,
-      title = "A very long title that must be wrapped in multiple lines",
-      poster_path = "https://dummyimage.com/500x750/000/fff.jpg",
-      overview = "Once upon a time...",
-      vote_average = 1.2,
-      release_date = "2022-02-03",
-    ),
-    navToDetail = {},
-  )
 }
 
 @Preview

--- a/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/TrendingLazyVerticalGridViewModel.kt
+++ b/trending/src/main/kotlin/net/marcoromano/mooviez/trending/widgets/trending/TrendingLazyVerticalGridViewModel.kt
@@ -22,7 +22,10 @@ internal class TrendingLazyVerticalGridViewModel @Inject constructor(
 ) : ViewModel() {
   @OptIn(ExperimentalPagingApi::class)
   val pager = Pager(
-    config = PagingConfig(pageSize = 20), // 20 comes from tmdb api docs
+    config = PagingConfig(
+      pageSize = 20, // 20 comes from tmdb api docs
+      enablePlaceholders = true,
+    ),
     remoteMediator = Mediator(httpApi = httpApi, database = database),
   ) {
     QueryPagingSource(


### PR DESCRIPTION
When going back to the list from a movie detail, the scroll position is not restored properly if the list was past the 1st page. This seems to be because the list will have to page again starting from the 1st page so the scroll position to restore is not there yet. Setting `enablePlaceholders = true` will make the pager emit placeholder items for items in the list which are in store but have not yet been added to the pager. This way the scroll position can be restored proeprly by the lazy column.