### PR TITLE
Enable enableBuildConfigAsBytecode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.variant.VariantOutputConfiguration
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 import java.time.Instant
 
@@ -10,7 +11,6 @@ plugins {
   id(libs.plugins.google.firebase.crashlytics.get().pluginId)
   id(libs.plugins.playPublisher.get().pluginId)
   id(libs.plugins.dagger.hilt.get().pluginId)
-  id(libs.plugins.google.secrets.get().pluginId)
   id(libs.plugins.kotlinter.get().pluginId)
 }
 
@@ -38,6 +38,10 @@ android {
     testInstrumentationRunnerArguments["clearPackageData"] = "true"
   }
   buildTypes {
+    val tmdbApiKey = System.getenv("TMDB_API_KEY") ?: gradleLocalProperties(rootDir).getProperty("tmdbApiKey")
+    buildTypes.forEach {
+      it.buildConfigField("String", "TMDB_API_KEY", "\"${tmdbApiKey}\"")
+    }
     getByName("debug") {
       versionNameSuffix = "-DEBUG"
     }
@@ -116,10 +120,6 @@ kapt {
 
 hilt {
   enableAggregatingTask = true
-}
-
-secrets {
-  defaultPropertiesFileName = "local.defaults.properties"
 }
 
 dependencies {

--- a/app/src/main/kotlin/net/marcoromano/mooviez/app/ApplicationModule.kt
+++ b/app/src/main/kotlin/net/marcoromano/mooviez/app/ApplicationModule.kt
@@ -21,5 +21,5 @@ object ApplicationModule {
 
   @Provides
   @Named("tmdbApiKey")
-  fun tmdbApiKey(): String = BuildConfig.tmdbApiKey
+  fun tmdbApiKey(): String = BuildConfig.TMDB_API_KEY
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
     classpath(libs.plugin.google.firebase.appDistribution)
     classpath(libs.plugin.google.firebase.crashlytics)
     classpath(libs.plugin.google.ksp)
-    classpath(libs.plugin.google.secrets)
     classpath(libs.plugin.google.services)
     classpath(libs.plugin.kotlin)
     classpath(libs.plugin.kotlin.serialization)

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+android.enableBuildConfigAsBytecode=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ plugin-dependencyUpdates = "0.46.0"
 plugin-google-firebase-appDistribution = "4.0.0"
 plugin-google-firebase-crashlytics = "2.9.5"
 plugin-google-ksp = "1.8.21-1.0.11"
-plugin-google-secrets = "2.0.1"
 plugin-google-services = "4.3.15"
 plugin-kotlinter = "3.15.0"
 plugin-playPublisher = "3.8.3"
@@ -41,7 +40,6 @@ dependencyUpdates = { id = "com.github.ben-manes.versions", version.ref = "plugi
 google-firebase-appDistribution = { id = "com.google.firebase.appdistribution", version.ref = "plugin-google-firebase-appDistribution" }
 google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "plugin-google-firebase-crashlytics" }
 google-ksp = { id = "com.google.devtools.ksp", version.ref = "plugin-google-ksp" }
-google-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "plugin-google-secrets" }
 google-services = { id = "com.google.gms.google-services", version.ref = "plugin-google-services" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -159,7 +157,6 @@ plugin-dependencyUpdates = { module = "com.github.ben-manes:gradle-versions-plug
 plugin-google-firebase-appDistribution = { module = "com.google.firebase:firebase-appdistribution-gradle", version.ref = "plugin-google-firebase-appDistribution" }
 plugin-google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "plugin-google-firebase-crashlytics" }
 plugin-google-ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "plugin-google-ksp" }
-plugin-google-secrets = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "plugin-google-secrets" }
 plugin-google-services = { module = "com.google.gms:google-services", version.ref = "plugin-google-services" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }

--- a/local.defaults.properties
+++ b/local.defaults.properties
@@ -1,1 +1,0 @@
-tmdbApiKey=doNotChangeMe


### PR DESCRIPTION
When android.enableBuildConfigAsBytecode=true, the BuildConfig file isn’t generated as a Java file, but as a compiled file. This avoids the Java compilation step!

See: https://medium.com/androiddevelopers/5-ways-to-prepare-your-app-build-for-android-studio-flamingo-release-da34616bb946