### PR TITLE
Dynamically adjust path separator in `conventions.settings.gradle.kts` for Windows compatibility.

### DIFF
--- a/build-logic/settings-conventions/src/main/kotlin/conventions.settings.gradle.kts
+++ b/build-logic/settings-conventions/src/main/kotlin/conventions.settings.gradle.kts
@@ -1,18 +1,21 @@
+import java.io.File.separator
+import java.io.File.separatorChar
+
 /**
  * Searches for subprojects' `build.gradle` files and prints their Gradle project path.
  */
 private val discoverSubprojects: () -> Array<String> = {
   rootDir.walkBottomUp().filter {
     it.parent != rootDir.path &&
-      it.parent != rootDir.path + "/buildSrc" &&
-      it.parent != rootDir.path + "/build-logic" &&
-      it.parent != rootDir.path + "/build-logic/build-conventions" &&
-      it.parent != rootDir.path + "/build-logic/settings-conventions" &&
+      it.parent != rootDir.path + "${separator}buildSrc" &&
+      it.parent != rootDir.path + "${separator}build-logic" &&
+      it.parent != rootDir.path + "${separator}build-logic${separator}build-conventions" &&
+      it.parent != rootDir.path + "${separator}build-logic${separator}settings-conventions" &&
       it.name == "build.gradle.kts"
   }.map {
     it.path.removePrefix(rootDir.path)
-      .removeSuffix("/build.gradle.kts")
-      .replace('/', ':')
+      .removeSuffix("${separator}build.gradle.kts")
+      .replace(separatorChar, ':')
   }.toList().toTypedArray()
 }
 


### PR DESCRIPTION
Allows the cradle build to run on Windows.